### PR TITLE
Prevent mangling of system frameworks

### DIFF
--- a/lib/cocoapods-packager/symbols.rb
+++ b/lib/cocoapods-packager/symbols.rb
@@ -12,7 +12,6 @@ module Symbols
 
   def classes_from_symbols(syms)
     classes = syms.select { |klass| klass[/OBJC_CLASS_\$_/] }
-    classes = classes.select { |klass| klass !~ /_NS|_UI/ }
     classes = classes.uniq
     classes.map! { |klass| klass.gsub(/^.*\$_/, '') }
   end

--- a/lib/cocoapods-packager/symbols.rb
+++ b/lib/cocoapods-packager/symbols.rb
@@ -1,6 +1,6 @@
 module Symbols
   def symbols_from_library(library)
-    syms = `nm -g #{library}`.split("\n")
+    syms = `nm -gU #{library}`.split("\n")
 
     result = classes_from_symbols(syms)
     result + constants_from_symbols(syms)


### PR DESCRIPTION
This is a result of #58 

The approach I have taken eliminates the need to individually exclude Apple prefixes from the mangling process. It now simply uses the `-U` option in `nm` to only mangle symbols defined in the library itself.

I believe this approach is solid but let me know what you think.