### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: objective-c
 cache: bundler
 before_install:
 - bundle install
-- bundle exec pod repo update
+- bundle exec pod repo update --silent
 script: bundle exec rake specs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: objective-c
 cache: bundler
-before_install: bundle install
+before_install:
+- bundle install
+- bundle exec pod repo update
 script: bundle exec rake specs

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -16,11 +16,14 @@ module Pod
         command.run
         `cp -Rp NikeKit-*/ios/NikeKit.framework spec/fixtures/PackagerTest`
 
+        log = ''
+
         Dir.chdir('spec/fixtures/PackagerTest') do
           `pod install 2>&1`
-          `xcodebuild -workspace PackagerTest.xcworkspace -scheme PackagerTest 2>&1`
+          log << `xcodebuild -workspace PackagerTest.xcworkspace -scheme PackagerTest 2>&1`
         end
 
+        puts log if $?.exitstatus != 0
         $?.exitstatus.should == 0
   	 end
 
@@ -30,12 +33,15 @@ module Pod
         command = Command.parse(%w{ package spec/fixtures/LibraryDemo.podspec })
         command.run
 
+        log = ''
+
         Dir.chdir('spec/fixtures/LibraryConsumerDemo') do
           `pod install 2>&1`
-          `xcodebuild -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
-          `xcodebuild -sdk iphonesimulator -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
+          log << `xcodebuild -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
+          log << `xcodebuild -sdk iphonesimulator -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
         end
 
+        puts log if $?.exitstatus != 0
         $?.exitstatus.should == 0
      end 
     end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -20,7 +20,7 @@ module Pod
 
         Dir.chdir('spec/fixtures/PackagerTest') do
           `pod install 2>&1`
-          log << `xcodebuild -workspace PackagerTest.xcworkspace -scheme PackagerTest 2>&1`
+          log << `xcodebuild -workspace PackagerTest.xcworkspace -scheme PackagerTest -sdk iphonesimulator CODE_SIGN_IDENTITY=- 2>&1`
         end
 
         puts log if $?.exitstatus != 0


### PR DESCRIPTION
- Run `pod repo update`
- No longer build integration specs for the device

In addition to that, some more detailed logs are now shown if the integration specs fail.