### PR TITLE
Local for spec by path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'bundler/gem_tasks'
 
 def specs(dir)
-  FileList["spec/#{dir}/*_spec.rb"].shuffle.join(' ')
+  FileList["spec/#{dir}/*_spec.rb"].map{|f| File.absolute_path(f)}.shuffle.join(' ')
 end
 
 desc 'Runs all the specs'

--- a/lib/cocoapods-packager/pod_utils.rb
+++ b/lib/cocoapods-packager/pod_utils.rb
@@ -5,7 +5,7 @@ module Pod
 
       def install_pod(platform_name)
         podfile = podfile_from_spec(
-          File.basename(@path),
+          @path && File.expand_path(@path),
           @spec.name,
           platform_name,
           @spec.deployment_target(platform_name),
@@ -27,18 +27,18 @@ module Pod
           if path
             if subspecs
               subspecs.each do |subspec|
-                pod spec_name + '/' + subspec, :podspec => path
+                pod spec_name + '/' + subspec, :path => File.dirname(path)
               end
             else
-              pod spec_name, :podspec => path
+              pod spec_name, :path => File.dirname(path)
             end
           else
             if subspecs
               subspecs.each do |subspec|
-                pod spec_name + '/' + subspec, :path => '.'
+                pod spec_name + '/' + subspec
               end
             else
-              pod spec_name, :path => '.'
+              pod spec_name
             end
           end
         end


### PR DESCRIPTION
I met the same issue as #63, then wrote a patch according to the comment: https://github.com/CocoaPods/cocoapods-packager/issues/63#issuecomment-72033381.
However, the change breaks almost all tests, which depend local podfile + remote GIT source style.
Because reordering them is not straight forward and there are several options (contain in repo, git submodule, change to name + remote podspec style, etc.), I stopped here.

I appreciate if we can discuss and this patch helps :smiley:  (and, feel free to reject)