### PR TITLE
Build with a spec's `compile_flags` directive.

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -78,7 +78,8 @@ module Pod
     def build_with_mangling(platform)
       UI.puts 'Mangling symbols'
       defines = Symbols.mangle_for_pod_dependencies(@spec.name, @sandbox_root)
-      defines += @spec.consumer(platform).compiler_flags.join(' ')
+      defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
+
       if platform.name == :ios
         defines = "#{defines} ARCHS=\"x86_64 i386 arm64 armv7 armv7s\""
       end
@@ -90,7 +91,7 @@ module Pod
 
     def compile(platform)
       defines = "GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_#{@spec.name}=PodsDummy_PodPackage_#{@spec.name}'"
-      defines += " #{@spec.consumer(platform).compiler_flags.join(' ')}"
+      defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
 
       if platform.name == :ios
         defines = "#{defines} ARCHS=\"x86_64 i386 arm64 armv7 armv7s\""

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -78,6 +78,7 @@ module Pod
     def build_with_mangling(platform)
       UI.puts 'Mangling symbols'
       defines = Symbols.mangle_for_pod_dependencies(@spec.name, @sandbox_root)
+      defines += @spec.consumer(platform).compiler_flags.join(' ')
       if platform.name == :ios
         defines = "#{defines} ARCHS=\"x86_64 i386 arm64 armv7 armv7s\""
       end
@@ -89,6 +90,7 @@ module Pod
 
     def compile(platform)
       defines = "GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_#{@spec.name}=PodsDummy_PodPackage_#{@spec.name}'"
+      defines += " #{@spec.consumer(platform).compiler_flags.join(' ')}"
 
       if platform.name == :ios
         defines = "#{defines} ARCHS=\"x86_64 i386 arm64 armv7 armv7s\""

--- a/spec/fixtures/Builder.podspec
+++ b/spec/fixtures/Builder.podspec
@@ -11,11 +11,15 @@ Pod::Spec.new do |s|
   s.libraries               = 'xml2'
   s.requires_arc            = true
   s.xcconfig                = { 'OTHER_LDFLAGS' => '-lObjC' }
+  s.compiler_flag           = "-DBASE_FLAG"
 
   s.ios.frameworks          = 'Foundation'
   s.ios.deployment_target   = '8.0'
+  s.ios.compiler_flag       = "-DIOS_FLAG"
 
   s.osx.frameworks          = 'AppKit'
+  s.osx.deployment_target   = "10.8"
   s.osx.requires_arc        = false
   s.osx.xcconfig            = { 'CFLAGS' => '-I.' }
+  s.osx.compiler_flag       = "-DOSX_FLAG"
 end

--- a/spec/specification/spec_builder_spec.rb
+++ b/spec/specification/spec_builder_spec.rb
@@ -21,36 +21,36 @@ module Pod
       return Specification.from_string(spec_string, 'Builder.podspec')
     end
 
-  	describe 'Preserve attributes from source specification' do
+    describe 'Preserve attributes from source specification' do
       before do
         @spec = Specification.from_file('spec/fixtures/Builder.podspec')
         @builder = SpecBuilder.new(@spec, nil, false)
       end
 
-  		it "preserves platform.frameworks" do
-  			spec = specification_from_builder(@builder)
+      it "preserves platform.frameworks" do
+        spec = specification_from_builder(@builder)
         compare_attributes(spec, @spec, 'frameworks')
-  		end
+      end
 
-  		it "preserves platform.libraries" do
-  			spec = specification_from_builder(@builder)
+      it "preserves platform.libraries" do
+        spec = specification_from_builder(@builder)
         compare_attributes(spec, @spec, 'libraries')
-  		end
+      end
 
-  		it "preserves platform.requires_arc" do
-  			spec = specification_from_builder(@builder)
+      it "preserves platform.requires_arc" do
+        spec = specification_from_builder(@builder)
         compare_attributes(spec, @spec, 'requires_arc')
-  		end
+      end
 
-  		it "preserves platform.deployment_target" do
-  			spec = specification_from_builder(@builder)
+      it "preserves platform.deployment_target" do
+        spec = specification_from_builder(@builder)
         compare_attributes(spec, @spec, 'deployment_target')
-  		end
+      end
 
-  		it "preserves platform.xcconfig" do
-  			spec = specification_from_builder(@builder)
+      it "preserves platform.xcconfig" do
+        spec = specification_from_builder(@builder)
         compare_attributes(spec, @spec, 'xcconfig')
-  		end
-  	end
+      end
+    end
   end
 end

--- a/spec/specification/spec_builder_spec.rb
+++ b/spec/specification/spec_builder_spec.rb
@@ -1,0 +1,56 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Pod
+  describe SpecBuilder do
+    def compare_attributes(first_spec, second_spec, attribute_name)
+      first_spec.attributes_hash[attribute_name].should ==
+        second_spec.attributes_hash[attribute_name]
+
+      %w(ios osx).each do |platform|
+        first_spec.attributes_hash[platform][attribute_name].should ==
+          second_spec.attributes_hash[platform][attribute_name]
+      end
+    end
+
+    def specification_from_builder(builder)
+      spec_string = builder.spec_metadata
+      spec_string += builder.spec_platform(Platform.ios)
+      spec_string += builder.spec_platform(Platform.osx)
+      spec_string += builder.spec_close
+
+      return Specification.from_string(spec_string, 'Builder.podspec')
+    end
+
+  	describe 'Preserve attributes from source specification' do
+      before do
+        @spec = Specification.from_file('spec/fixtures/Builder.podspec')
+        @builder = SpecBuilder.new(@spec, nil, false)
+      end
+
+  		it "preserves platform.frameworks" do
+  			spec = specification_from_builder(@builder)
+        compare_attributes(spec, @spec, 'frameworks')
+  		end
+
+  		it "preserves platform.libraries" do
+  			spec = specification_from_builder(@builder)
+        compare_attributes(spec, @spec, 'libraries')
+  		end
+
+  		it "preserves platform.requires_arc" do
+  			spec = specification_from_builder(@builder)
+        compare_attributes(spec, @spec, 'requires_arc')
+  		end
+
+  		it "preserves platform.deployment_target" do
+  			spec = specification_from_builder(@builder)
+        compare_attributes(spec, @spec, 'deployment_target')
+  		end
+
+  		it "preserves platform.xcconfig" do
+  			spec = specification_from_builder(@builder)
+        compare_attributes(spec, @spec, 'xcconfig')
+  		end
+  	end
+  end
+end


### PR DESCRIPTION
This change makes cocoapods-packager use a podspec's `compiler_flag`/`compiler_flags` when building the pod for packaging. Two further related changes are made:

* In addition to adding tests for the new behaviour, tests for the code that produced compiler flags (e.g. GCC_PREPROCESSOR_DEFINITIONS and ARCHS) are added.

* It renames the old `specs/specification/builder_spec.rb` to `specs/specification/spec_builder_spec.rb` which is a better name (it tests the `SpecBuilder` class, not `Builder`).

Note that it does not add these compiler flags to the generated podspec, so a project using the generated pod will not have these flags set. I think this is the expected behaviour.