### PR TITLE
Catch build errors during `pod package`.

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -1,14 +1,5 @@
 module Pod
   class Builder
-    class BuildFailedException < RuntimeError
-      attr_accessor :command, :output
-
-      def initialize(command, output)
-        @command = command
-        @output = output
-      end
-    end
-
 
     def initialize(source_dir, sandbox_root, public_headers_root, spec, embedded, mangle)
       @source_dir = source_dir

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -1,6 +1,5 @@
 module Pod
   class Builder
-
     def initialize(source_dir, sandbox_root, public_headers_root, spec, embedded, mangle)
       @source_dir = source_dir
       @sandbox_root = sandbox_root

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -181,6 +181,12 @@ MAP
         puts "Build command failed: #{command}"
         puts "Output:"
         output.each { |line| puts "    #{line}" }
+
+        # Note: We use `Process.exit` here because it fires a `SystemExit`
+        # exception, which gives the caller a chance to clean up before the
+        # process terminates.
+        #
+        # See http://ruby-doc.org/core-1.9.3/Process.html#method-c-exit
         Process.exit
       end
     end

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -185,11 +185,10 @@ MAP
 
     def xcodebuild(defines = '', args = '', build_dir = 'build')
       command = "xcodebuild #{defines} CONFIGURATION_BUILD_DIR=#{build_dir} clean build #{args} -configuration Release -target Pods -project #{@sandbox_root}/Pods.xcodeproj 2>&1"
-      log = []
-      `#{command}`.lines.each { |line| log << line }
+      output = `#{command}`.lines.to_a
 
       if $?.exitstatus != 0
-        raise BuildFailedException.new(command, log)
+        raise BuildFailedException.new(command, output)
       end
     end
   end

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -178,9 +178,7 @@ MAP
       output = `#{command}`.lines.to_a
 
       if $?.exitstatus != 0
-        puts "Build command failed: #{command}"
-        puts "Output:"
-        output.each { |line| puts "    #{line}" }
+        puts UI::BuildFailedReport.report(command, output)
 
         # Note: We use `Process.exit` here because it fires a `SystemExit`
         # exception, which gives the caller a chance to clean up before the

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -188,7 +188,10 @@ MAP
       output = `#{command}`.lines.to_a
 
       if $?.exitstatus != 0
-        raise BuildFailedException.new(command, output)
+        puts "Build command failed: #{command}"
+        puts "Output:"
+        output.each { |line| puts "    #{line}" }
+        Process.exit
       end
     end
   end

--- a/lib/cocoapods-packager/user_interface/build_failed_report.rb
+++ b/lib/cocoapods-packager/user_interface/build_failed_report.rb
@@ -1,0 +1,15 @@
+module Pod
+  module UserInterface
+    module BuildFailedReport
+      class << self
+        def report(command, output)
+          <<-EOF
+Build command failed: #{command}"
+Output:
+#{output.map { |line| "    #{line}" }.join}
+          EOF
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods-packager/user_interface/build_failed_report.rb
+++ b/lib/cocoapods-packager/user_interface/build_failed_report.rb
@@ -4,7 +4,7 @@ module Pod
       class << self
         def report(command, output)
           <<-EOF
-Build command failed: #{command}"
+Build command failed: #{command}
 Output:
 #{output.map { |line| "    #{line}" }.join}
           EOF

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,4 +1,5 @@
 require 'pod/command/package'
+require 'cocoapods-packager/user_interface/build_failed_report'
 require 'cocoapods-packager/builder'
 require 'cocoapods-packager/framework'
 require 'cocoapods-packager/mangle'

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -70,12 +70,6 @@ module Pod
         begin
           perform_build(platform, sandbox)
 
-        rescue Pod::Builder::BuildFailedException => ex
-          puts "Build command failed: #{ex.command}"
-          puts "Output:"
-          ex.output.each { |line| puts "    #{line}" }
-          Process.exit
-
         ensure
           Pathname.new(config.sandbox_root).rmtree
           FileUtils.rm_f('Podfile.lock')

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -67,10 +67,19 @@ module Pod
 
         sandbox = install_pod(platform.name)
 
-        perform_build(platform, sandbox)
+        begin
+          perform_build(platform, sandbox)
 
-        Pathname.new(config.sandbox_root).rmtree
-        FileUtils.rm_f('Podfile.lock')
+        rescue Pod::Builder::BuildFailedException => ex
+          puts "Build command failed: #{ex.command}"
+          puts "Output:"
+          ex.output.each { |line| puts "    #{line}" }
+          raise ex
+
+        ensure
+          Pathname.new(config.sandbox_root).rmtree
+          FileUtils.rm_f('Podfile.lock')
+        end
       end
 
       def build_package

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -74,7 +74,7 @@ module Pod
           puts "Build command failed: #{ex.command}"
           puts "Output:"
           ex.output.each { |line| puts "    #{line}" }
-          raise ex
+          Process.exit
 
         ensure
           Pathname.new(config.sandbox_root).rmtree

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -70,7 +70,7 @@ module Pod
         begin
           perform_build(platform, sandbox)
 
-        ensure
+        ensure # in case the build fails; see Builder#xcodebuild.
           Pathname.new(config.sandbox_root).rmtree
           FileUtils.rm_f('Podfile.lock')
         end

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -2,22 +2,38 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 module Pod
   describe Builder do
-    before do
-      @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-
-      @builder = Builder.new(nil, nil, nil, @spec, nil, nil)
-    end
-
     describe 'Xcodebuild command' do
+      describe 'compiler flags' do
+        before do
+          @spec = Specification.from_file('spec/fixtures/Builder.podspec')
+          @builder = Builder.new(nil, nil, nil, @spec, nil, nil)
+        end
 
-      it "includes proper compiler flags for iOS" do
-        @builder.expects(:xcodebuild).with('GCC_PREPROCESSOR_DEFINITIONS=\'PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder\' -DBASE_FLAG -DIOS_FLAG ARCHS="x86_64 i386 arm64 armv7 armv7s"').returns(nil)
-        @builder.compile(Platform.new(:ios))
+        it "includes proper compiler flags for iOS" do
+          @builder.expects(:xcodebuild).with('GCC_PREPROCESSOR_DEFINITIONS=\'PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder\' -DBASE_FLAG -DIOS_FLAG ARCHS="x86_64 i386 arm64 armv7 armv7s"').returns(nil)
+          @builder.compile(Platform.new(:ios))
+        end
+
+        it "includes proper compiler flags for OSX" do
+          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DOSX_FLAG").returns(nil)
+          @builder.compile(Platform.new(:osx))
+        end
       end
 
-      it "includes proper compiler flags for OSX" do
-        @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DOSX_FLAG").returns(nil)
-        @builder.compile(Platform.new(:osx))
+      describe 'on build failure' do
+        before do
+          @spec = Specification.from_file('spec/fixtures/Builder.podspec')
+          @builder = Builder.new(nil, nil, nil, @spec, nil, nil)
+        end
+
+        it 'dumps report and terminates' do
+          UI::BuildFailedReport.expects(:report).returns(nil)
+
+          should.raise SystemExit do
+            # TODO: check that it dumps report
+            @builder.compile(Platform.new(:ios))
+          end
+        end
       end
     end
   end

--- a/spec/user_interface/build_failed_report_spec.rb
+++ b/spec/user_interface/build_failed_report_spec.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Pod
+  module UserInterface
+    describe BuildFailedReport do
+      it 'should format a report correctly' do
+        UI::BuildFailedReport.report('a', ['b']).should == "Build command failed: a\nOutput:\n    b\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request fixes #47 by throwing an exception when `xcodebuild` commands fail.

There's no automated tests accompanying this, but the surrounding code is also untested. I'm open to suggestions about the best way to approach adding tests.