### PR TITLE
care for 'module_map' directive

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -112,7 +112,14 @@ module Pod
       Dir.glob("#{headers_source_root}/**/*.h").
         each { |h| `ditto #{h} #{@fwk.headers_path}/#{h.sub(headers_source_root, '')}` }
 
-      if File.exist?("#{@public_headers_root}/#{@spec.name}/#{@spec.name}.h")
+      # if custom 'module_map' is specified add it
+      # to the framework distribution, otherwise check
+      # if a header exists that is equal to 'spec.name'', if so
+      # create a default 'module-map' one using it.
+      if @spec.module_map
+        module_map_file = "#{@sandbox_root}/#{@spec.name}/#{@spec.module_map}"
+        module_map = File.read(module_map_file) if Pathname(module_map_file).exist?
+      elsif File.exist?("#{@public_headers_root}/#{@spec.name}/#{@spec.name}.h")
         module_map = <<MAP
 framework module #{@spec.name} {
   umbrella header "#{@spec.name}.h"
@@ -121,7 +128,9 @@ framework module #{@spec.name} {
   module * { export * }
 }
 MAP
+      end
 
+      if module_map
         @fwk.module_map_path.mkpath unless @fwk.module_map_path.exist?
         File.write("#{@fwk.module_map_path}/module.modulemap", module_map)
       end


### PR DESCRIPTION
@neonichu as discussed in [issue#77](https://github.com/CocoaPods/cocoapods-packager/issues/77) here is a first pass on checking for the existence of ```module_map``` and act accordingly during the framework generation.

Let me know what you think, thanks!
