### PR TITLE
Feature/support dynamic frameworks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,8 +67,8 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     metaclass (0.0.4)
-    mime-types (2.6.1)
-    minitest (5.8.0)
+    mime-types (2.6.2)
+    minitest (5.8.1)
     mocha (0.11.4)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.1)
@@ -115,4 +115,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -106,7 +106,7 @@ module Pod
       linker_flags = static_linker_flags_in_sandbox
       defines = "#{defines} OTHER_LDFLAGS=\"#{linker_flags.join(' ')}\""
 
-      # Build Target Dynamic Framework for both device and Simulator
+      # Build Target Dynamic Framework for osx
       defines = "#{defines} LIBRARY_SEARCH_PATHS=\"#{Dir.pwd}/#{@static_sandbox_root}/build\""
       xcodebuild(defines, nil, 'build', "#{@spec.name}", "#{@dynamic_sandbox_root}")
 

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -252,6 +252,11 @@ MAP
     end
 
     def xcodebuild(defines = '', args = '', build_dir = 'build', target = 'Pods', project_root = @static_sandbox_root)
+
+      if defined?(CODESIGN_NOT_REQUIRED)
+        args = "#{args} CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
+      end
+
       command = "xcodebuild #{defines} #{args} CONFIGURATION_BUILD_DIR=#{build_dir} clean build -configuration Release -target #{target} -project #{project_root}/Pods.xcodeproj 2>&1"
       output = `#{command}`.lines.to_a
 

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -86,7 +86,7 @@ module Pod
       linker_flags = static_linker_flags_in_sandbox
       defines = "#{defines} OTHER_LDFLAGS=\"#{linker_flags.join(' ')}\""
 
-      # Build Target Dynamic Framework for both iPhone and Simulator
+      # Build Target Dynamic Framework for both device and Simulator
       device_defines = "#{defines} LIBRARY_SEARCH_PATHS=\"#{Dir.pwd}/#{@static_sandbox_root}/build\""
       device_options = ios_build_options << " -sdk iphoneos"
       xcodebuild(device_defines, device_options, 'build', "#{@spec.name}", "#{@dynamic_sandbox_root}")
@@ -97,8 +97,8 @@ module Pod
       # Combine architectures
       `lipo #{@dynamic_sandbox_root}/build/#{@spec.name}.framework/#{@spec.name} #{@dynamic_sandbox_root}/build-sim/#{@spec.name}.framework/#{@spec.name} -create -output #{output}`
 
-      FileUtils.mkdir('ios')
-      `mv #{@dynamic_sandbox_root}/build/#{@spec.name}.framework ios`
+      FileUtils.mkdir("#{platform.name}")
+      `mv #{@dynamic_sandbox_root}/build/#{@spec.name}.framework #{platform.name}`
     end
 
     def build_dynamic_framework_for_mac(platform, defines, output)

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -102,7 +102,16 @@ module Pod
     end
 
     def build_dynamic_framework_for_mac(platform, defines, output)
-      #TODO Add support for dynamic frameworks on mac
+      # Specify frameworks to link and search paths
+      linker_flags = static_linker_flags_in_sandbox
+      defines = "#{defines} OTHER_LDFLAGS=\"#{linker_flags.join(' ')}\""
+
+      # Build Target Dynamic Framework for both device and Simulator
+      defines = "#{defines} LIBRARY_SEARCH_PATHS=\"#{Dir.pwd}/#{@static_sandbox_root}/build\""
+      xcodebuild(defines, nil, 'build', "#{@spec.name}", "#{@dynamic_sandbox_root}")
+
+      FileUtils.mkdir("#{platform.name}")
+      `mv #{@dynamic_sandbox_root}/build/#{@spec.name}.framework #{platform.name}`
     end
 
     def build_sim_libraries(platform, defines)

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -253,7 +253,7 @@ MAP
 
     def xcodebuild(defines = '', args = '', build_dir = 'build', target = 'Pods', project_root = @static_sandbox_root)
 
-      if defined?(CODESIGN_NOT_REQUIRED)
+      if defined?(DONT_CODESIGN)
         args = "#{args} CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
       end
 

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -1,12 +1,14 @@
 module Pod
   class Builder
-    def initialize(source_dir, sandbox_root, public_headers_root, spec, embedded, mangle)
+    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, dynamic)
       @source_dir = source_dir
-      @sandbox_root = sandbox_root
+      @static_sandbox_root = static_sandbox_root
+      @dynamic_sandbox_root = dynamic_sandbox_root
       @public_headers_root = public_headers_root
       @spec = spec
       @embedded = embedded
       @mangle = mangle
+      @dynamic = dynamic
     end
 
     def build(platform, library)
@@ -21,6 +23,8 @@ module Pod
       UI.puts('Building static library')
 
       defines = compile(platform)
+      build_sim_libraries(platform, defines)
+
       platform_path = Pathname.new(platform.name.to_s)
       platform_path.mkdir unless platform_path.exist?
       build_library(platform, defines, platform_path + Pathname.new("lib#{@spec.name}.a"))
@@ -30,11 +34,18 @@ module Pod
       UI.puts('Building framework')
 
       defines = compile(platform)
-      create_framework(platform.name.to_s)
-      copy_headers
-      build_library(platform, defines, @fwk.versions_path + Pathname.new(@spec.name))
-      copy_license
-      copy_resources(platform)
+      build_sim_libraries(platform, defines)
+
+      if @dynamic
+        build_dynamic_framework(platform, defines, "#{@dynamic_sandbox_root}/build/#{@spec.name}.framework/#{@spec.name}")
+        copy_resources(platform)
+      else
+        create_framework(platform.name.to_s)
+        build_library(platform, defines, @fwk.versions_path + Pathname.new(@spec.name))
+        copy_headers
+        copy_license
+        copy_resources(platform)
+      end
     end
 
     def link_embedded_resources
@@ -49,6 +60,17 @@ module Pod
 
     :private
 
+    def build_dynamic_framework(platform, defines, output)
+      UI.puts 'Building dynamic Framework'
+
+      clean_directory_for_dynamic_build
+      if platform.name == :ios
+        build_dynamic_framework_for_ios(platform, defines, output)
+      else
+        build_dynamic_framework_for_mac(platform, defines, output)
+      end
+    end
+
     def build_library(platform, defines, output)
       static_libs = static_libs_in_sandbox
 
@@ -59,15 +81,44 @@ module Pod
       end
     end
 
+    def build_dynamic_framework_for_ios(platform, defines, output)
+      # Specify frameworks to link and search paths
+      linker_flags = static_linker_flags_in_sandbox
+      defines = "#{defines} OTHER_LDFLAGS=\"#{linker_flags.join(' ')}\""
+
+      # Build Target Dynamic Framework for both iPhone and Simulator
+      device_defines = "#{defines} LIBRARY_SEARCH_PATHS=\"#{Dir.pwd}/#{@static_sandbox_root}/build\""
+      device_options = ios_build_options << " -sdk iphoneos"
+      xcodebuild(device_defines, device_options, 'build', "#{@spec.name}", "#{@dynamic_sandbox_root}")
+
+      sim_defines = "#{defines} LIBRARY_SEARCH_PATHS=\"#{Dir.pwd}/#{@static_sandbox_root}/build-sim\" ONLY_ACTIVE_ARCH=NO"
+      xcodebuild(sim_defines, '-sdk iphonesimulator', 'build-sim', "#{@spec.name}", "#{@dynamic_sandbox_root}")
+
+      # Combine architectures
+      `lipo #{@dynamic_sandbox_root}/build/#{@spec.name}.framework/#{@spec.name} #{@dynamic_sandbox_root}/build-sim/#{@spec.name}.framework/#{@spec.name} -create -output #{output}`
+
+      FileUtils.mkdir('ios')
+      `mv #{@dynamic_sandbox_root}/build/#{@spec.name}.framework ios`
+    end
+
+    def build_dynamic_framework_for_mac(platform, defines, output)
+      #TODO Add support for dynamic frameworks on mac
+    end
+
+    def build_sim_libraries(platform, defines)
+      if platform.name == :ios
+        xcodebuild(defines, '-sdk iphonesimulator', 'build-sim')
+      end
+    end
+
     def build_static_lib_for_ios(static_libs, defines, output)
       return if static_libs.count == 0
-      `libtool -static -o #{@sandbox_root}/build/package.a #{static_libs.join(' ')}`
+      `libtool -static -o #{@static_sandbox_root}/build/package.a #{static_libs.join(' ')}`
 
-      xcodebuild(defines, '-sdk iphonesimulator', 'build-sim')
       sim_libs = static_libs_in_sandbox('build-sim')
-      `libtool -static -o #{@sandbox_root}/build-sim/package.a #{sim_libs.join(' ')}`
+      `libtool -static -o #{@static_sandbox_root}/build-sim/package.a #{sim_libs.join(' ')}`
 
-      `lipo #{@sandbox_root}/build/package.a #{@sandbox_root}/build-sim/package.a -create -output #{output}`
+      `lipo #{@static_sandbox_root}/build/package.a #{@static_sandbox_root}/build-sim/package.a -create -output #{output}`
     end
 
     def build_static_lib_for_mac(static_libs, output)
@@ -77,7 +128,7 @@ module Pod
 
     def build_with_mangling(platform, options)
       UI.puts 'Mangling symbols'
-      defines = Symbols.mangle_for_pod_dependencies(@spec.name, @sandbox_root)
+      defines = Symbols.mangle_for_pod_dependencies(@spec.name, @static_sandbox_root)
       defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
 
       UI.puts 'Building mangled framework'
@@ -85,13 +136,21 @@ module Pod
       defines
     end
 
+    def clean_directory_for_dynamic_build
+      # Remove static headers to avoid duplicate declaration conflicts
+      FileUtils.rm_rf("#{@static_sandbox_root}/Headers/Public/#{@spec.name}")
+      FileUtils.rm_rf("#{@static_sandbox_root}/Headers/Private/#{@spec.name}")
+
+      # Equivalent to removing derrived data
+      FileUtils.rm_rf("Pods/build")
+    end
+
     def compile(platform)
       defines = "GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_#{@spec.name}=PodsDummy_PodPackage_#{@spec.name}'"
       defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
 
-      options = ""
       if platform.name == :ios
-        options = "ARCHS=\"arm64 armv7 armv7s\" OTHER_CFLAGS=\"-fembed-bitcode\"" 
+        options = ios_build_options
       end
 
       xcodebuild(defines, options)
@@ -113,7 +172,7 @@ module Pod
       # otherwise check if a header exists that is equal to 'spec.name', if so
       # create a default 'module_map' one using it.
       if !@spec.module_map.nil?
-        module_map_file = "#{@sandbox_root}/#{@spec.name}/#{@spec.module_map}"
+        module_map_file = "#{@static_sandbox_root}/#{@spec.name}/#{@spec.module_map}"
         module_map = File.read(module_map_file) if Pathname(module_map_file).exist?
       elsif File.exist?("#{@public_headers_root}/#{@spec.name}/#{@spec.name}.h")
         module_map = <<MAP
@@ -134,22 +193,24 @@ MAP
 
     def copy_license
       license_file = @spec.license[:file] || 'LICENSE'
-      license_file = "#{@sandbox_root}/#{@spec.name}/#{license_file}"
       `cp "#{license_file}" .` if Pathname(license_file).exist?
     end
 
     def copy_resources(platform)
-      bundles = Dir.glob("#{@sandbox_root}/build/*.bundle")
-      `cp -rp #{@sandbox_root}/build/*.bundle #{@fwk.resources_path} 2>&1`
-
-      resources = expand_paths(@spec.consumer(platform).resources)
-      if resources.count == 0 && bundles.count == 0
-        @fwk.delete_resources
-        return
-      end
-
-      if resources.count > 0
-        `cp -rp #{resources.join(' ')} #{@fwk.resources_path}`
+      bundles = Dir.glob("#{@static_sandbox_root}/build/*.bundle")
+      if @dynamic
+        resources_path = "ios/#{@spec.name}.framework"
+        `cp -rp #{@static_sandbox_root}/build/*.bundle #{resources_path} 2>&1`
+      else
+        `cp -rp #{@static_sandbox_root}/build/*.bundle #{@fwk.resources_path} 2>&1`
+        resources = expand_paths(@spec.consumer(platform).resources)
+        if resources.count == 0 && bundles.count == 0
+          @fwk.delete_resources
+          return
+        end
+        if resources.count > 0
+          `cp -rp #{resources.join(' ')} #{@fwk.resources_path}`
+        end
       end
     end
 
@@ -175,11 +236,23 @@ MAP
     end
 
     def static_libs_in_sandbox(build_dir = 'build')
-      Dir.glob("#{@sandbox_root}/#{build_dir}/lib*.a")
+      Dir.glob("#{@static_sandbox_root}/#{build_dir}/lib*.a")
     end
 
-    def xcodebuild(defines = '', args = '', build_dir = 'build')
-      command = "xcodebuild #{defines} CONFIGURATION_BUILD_DIR=#{build_dir} clean build #{args} -configuration Release -target Pods -project #{@sandbox_root}/Pods.xcodeproj 2>&1"
+    def static_linker_flags_in_sandbox
+      linker_flags = static_libs_in_sandbox.map do |lib|
+        lib.slice!("lib")
+        lib_flag = lib.chomp(".a").split("/").last
+        "-l#{lib_flag}"
+      end
+    end
+
+    def ios_build_options
+      return "ARCHS=\'x86_64 i386 arm64 armv7 armv7s\' OTHER_CFLAGS=\'-fembed-bitcode\'"
+    end
+
+    def xcodebuild(defines = '', args = '', build_dir = 'build', target = 'Pods', project_root = @static_sandbox_root)
+      command = "xcodebuild #{defines} #{args} CONFIGURATION_BUILD_DIR=#{build_dir} clean build -configuration Release -target #{target} -project #{project_root}/Pods.xcodeproj 2>&1"
       output = `#{command}`.lines.to_a
 
       if $?.exitstatus != 0

--- a/lib/cocoapods-packager/pod_utils.rb
+++ b/lib/cocoapods-packager/pod_utils.rb
@@ -236,12 +236,6 @@ module Pod
           dynamic_project.targets.first.build_configuration_list.build_configurations.each do |config|
             config.build_settings['HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
             config.build_settings['USER_HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
-
-            if defined?(CODESIGN_NOT_REQUIRED)
-              config.build_settings['CODE_SIGN_IDENTITY'] = ""
-              config.build_settings['CODE_SIGNING_REQUIRED'] = "NO"
-            end
-
           end
           dynamic_project.save
         end

--- a/lib/cocoapods-packager/pod_utils.rb
+++ b/lib/cocoapods-packager/pod_utils.rb
@@ -3,7 +3,16 @@ module Pod
     class Package < Command
       :private
 
-      def install_pod(platform_name)
+      def build_static_sandbox(dynamic)
+        if dynamic
+          static_sandbox_root = Pathname.new(config.sandbox_root + "/Static")
+        else
+          static_sandbox_root = Pathname.new(config.sandbox_root)
+        end
+        Sandbox.new(static_sandbox_root)
+      end
+
+      def install_pod(platform_name, sandbox)
         podfile = podfile_from_spec(
           File.basename(@path),
           @spec.name,
@@ -13,25 +22,25 @@ module Pod
           @spec_sources,
         )
 
-        sandbox = Sandbox.new(config.sandbox_root)
-        installer = Installer.new(sandbox, podfile)
-        installer.install!
+        static_installer = Installer.new(sandbox, podfile)
+        static_installer.install!
 
-        unless installer.nil?
-          installer.pods_project.targets.each do |target|
+        unless static_installer.nil?
+          static_installer.pods_project.targets.each do |target|
             target.build_configurations.each do |config|
               config.build_settings['CLANG_MODULES_AUTOLINK'] = 'NO'
               config.build_settings['GCC_GENERATE_DEBUGGING_SYMBOLS'] = 'NO'
             end
           end
-          installer.pods_project.save
+          static_installer.pods_project.save
         end
 
-        sandbox
+        static_installer
       end
 
       def podfile_from_spec(path, spec_name, platform_name, deployment_target, subspecs, sources)
         Pod::Podfile.new do
+
           sources.each { |s| source s }
           platform(platform_name, deployment_target)
           if path
@@ -78,6 +87,7 @@ module Pod
       end
 
       def spec_with_path(path)
+
         return if path.nil? || !Pathname.new(path).exist?
 
         @path = path
@@ -93,6 +103,144 @@ module Pod
         end
 
         Specification.from_file(path)
+      end
+
+
+      #----------------------
+      # Dynamic Project Setup
+      #----------------------
+
+      def build_dynamic_sandbox(static_sandbox, static_installer)
+        dynamic_sandbox_root = Pathname.new(config.sandbox_root + "/Dynamic")
+        dynamic_sandbox = Sandbox.new(dynamic_sandbox_root)
+
+        dynamic_sandbox
+      end
+
+      def install_dynamic_pod(dynamic_sandbox, static_sandbox, static_installer)
+        # 1 Create a dynamic target for only the spec pod.
+        dynamic_target = build_dynamic_target(dynamic_sandbox, static_installer)
+
+        # 2. Build a new xcodeproj in the dynamic_sandbox with only the spec pod as a target.
+        project = prepare_pods_project(dynamic_sandbox, dynamic_target.name, static_installer)
+
+        # 3. Copy the source directory for the dynamic framework from the static sandbox.
+        copy_dynamic_target(static_sandbox, dynamic_target, dynamic_sandbox)
+
+        # 4. Copy the supporting files for the dynamic framework from the static sandbox.
+        copy_dynamic_supporting_files(static_sandbox, dynamic_target, dynamic_sandbox)
+
+        # 5. Update the file accecssors.
+        dynamic_target = update_file_accessors(dynamic_target, dynamic_sandbox)
+
+        # 6. Create the file references.
+        install_file_references(dynamic_sandbox, [dynamic_target], project)
+
+        # 7. Install the target.
+        install_library(dynamic_sandbox, dynamic_target)
+
+        # 9. Write the actual Xcodeproject to the dynamic sandbox.
+        write_pod_project(project, dynamic_sandbox)
+
+      end
+
+      def build_dynamic_target(dynamic_sandbox, static_installer)
+        spec_targets = static_installer.pod_targets.select do |target|
+          target.name == @spec.name
+        end
+        static_target = spec_targets[0]
+
+        dynamic_target = Pod::PodTarget.new(static_target.specs, static_target.target_definitions, dynamic_sandbox)
+        dynamic_target.host_requires_frameworks = true
+        dynamic_target.user_build_configurations = static_target.user_build_configurations
+        dynamic_target
+      end
+
+      def prepare_pods_project(dynamic_sandbox, spec_name, installer)
+        # Create a new pods project
+        pods_project = Pod::Project.new(dynamic_sandbox.project_path)
+
+        # Update build configurations
+        installer.analysis_result.all_user_build_configurations.each do |name, type|
+          pods_project.add_build_configuration(name, type)
+        end
+
+        # Add the pod group for only the dynamic framework
+        local = dynamic_sandbox.local?(spec_name)
+        path = dynamic_sandbox.pod_dir(spec_name)
+        was_absolute = dynamic_sandbox.local_path_was_absolute?(spec_name)
+        pods_project.add_pod_group(spec_name, path, local, was_absolute)
+
+        dynamic_sandbox.project = pods_project
+        pods_project
+      end
+
+
+      def copy_dynamic_target(static_sandbox, dynamic_target, dynamic_sandbox)
+        command = "cp -a #{static_sandbox.root}/#{@spec.name} #{dynamic_sandbox.root}"
+        `#{command}`
+      end
+
+      def copy_dynamic_supporting_files(static_sandbox, dynamic_target, dynamic_sandbox)
+        support_dir = Pathname.new(dynamic_target.support_files_dir.to_s.chomp("/#{dynamic_target.name}"))
+        support_dir.mkdir
+      end
+
+      def update_file_accessors(dynamic_target, dynamic_sandbox)
+        pod_root = dynamic_sandbox.pod_dir(dynamic_target.root_spec.name)
+
+        path_list = Sandbox::PathList.new(pod_root)
+        file_accessors = dynamic_target.specs.map do |spec|
+          Sandbox::FileAccessor.new(path_list, spec.consumer(dynamic_target.platform))
+        end
+
+        dynamic_target.file_accessors = file_accessors
+        dynamic_target
+      end
+
+      def install_file_references(dynamic_sandbox, pod_targets, pods_project)
+        installer = Pod::Installer::FileReferencesInstaller.new(dynamic_sandbox, pod_targets, pods_project)
+        installer.install!
+      end
+
+      def install_library(dynamic_sandbox, dynamic_target)
+        return if dynamic_target.target_definitions.flat_map(&:dependencies).empty?
+        target_installer = Pod::Installer::PodTargetInstaller.new(dynamic_sandbox, dynamic_target)
+        target_installer.install!
+
+        # Installs System Frameworks
+        dynamic_target.file_accessors.each do |file_accessor|
+          file_accessor.spec_consumer.frameworks.each do |framework|
+            if dynamic_target.should_build?
+              dynamic_target.native_target.add_system_framework(framework)
+            end
+          end
+
+          file_accessor.spec_consumer.libraries.each do |library|
+            if dynamic_target.should_build?
+              dynamic_target.native_target.add_system_library(library)
+            end
+          end
+        end
+      end
+
+      def write_pod_project(dynamic_project, dynamic_sandbox)
+
+        UI.message "- Writing Xcode project file to #{UI.path dynamic_sandbox.project_path}" do
+          dynamic_project.pods.remove_from_project if dynamic_project.pods.empty?
+          dynamic_project.development_pods.remove_from_project if dynamic_project.development_pods.empty?
+          dynamic_project.sort(:groups_position => :below)
+          dynamic_project.recreate_user_schemes(false)
+          dynamic_project.predictabilize_uuids if config.deterministic_uuids?
+
+          # Edit search paths so that we can find our dependency headers
+          dynamic_project.targets.first.build_configuration_list.build_configurations.each do |config|
+            config.build_settings['HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
+            config.build_settings['USER_HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
+          end
+
+          dynamic_project.save
+        end
       end
     end
   end

--- a/lib/cocoapods-packager/pod_utils.rb
+++ b/lib/cocoapods-packager/pod_utils.rb
@@ -65,7 +65,6 @@ module Pod
 
       def binary_only?(spec)
         deps = spec.dependencies.map { |dep| spec_with_name(dep.name) }
-
         [spec, *deps].each do |specification|
           %w(vendored_frameworks vendored_libraries).each do |attrib|
             if specification.attributes_hash[attrib]
@@ -237,8 +236,13 @@ module Pod
           dynamic_project.targets.first.build_configuration_list.build_configurations.each do |config|
             config.build_settings['HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
             config.build_settings['USER_HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
-          end
 
+            if defined?(CODESIGN_NOT_REQUIRED)
+              config.build_settings['CODE_SIGN_IDENTITY'] = ""
+              config.build_settings['CODE_SIGNING_REQUIRED'] = "NO"
+            end
+
+          end
           dynamic_project.save
         end
       end

--- a/lib/cocoapods-packager/spec_builder.rb
+++ b/lib/cocoapods-packager/spec_builder.rb
@@ -1,9 +1,10 @@
 module Pod
   class SpecBuilder
-    def initialize(spec, source, embedded)
+    def initialize(spec, source, embedded, dynamic)
       @spec = spec
       @source = source.nil? ? '{}' : source
       @embedded = embedded
+      @dynamic = dynamic
     end
 
     def framework_path
@@ -16,13 +17,19 @@ module Pod
 
     def spec_platform(platform)
       fwk_base = platform.name.to_s + '/' + framework_path
-      spec = <<SPEC
+      if @dynamic
+        spec = <<SPEC
+  s.#{platform.name}.vendored_framework   = '#{fwk_base}'
+SPEC
+      else
+       spec = <<SPEC
   s.#{platform.name}.platform             = :#{platform.symbolic_name}, '#{platform.deployment_target}'
   s.#{platform.name}.preserve_paths       = '#{fwk_base}'
   s.#{platform.name}.public_header_files  = '#{fwk_base}/Versions/A/Headers/*.h'
   s.#{platform.name}.resource             = '#{fwk_base}/Versions/A/Resources/**/*'
   s.#{platform.name}.vendored_frameworks  = '#{fwk_base}'
 SPEC
+      end
 
       %w(frameworks libraries requires_arc xcconfig).each do |attribute|
         attributes_hash = @spec.attributes_hash[platform.name.to_s]

--- a/lib/cocoapods-packager/spec_builder.rb
+++ b/lib/cocoapods-packager/spec_builder.rb
@@ -18,9 +18,10 @@ module Pod
     def spec_platform(platform)
       fwk_base = platform.name.to_s + '/' + framework_path
       if @dynamic
-        spec = <<SPEC
+        spec = <<RB
+  s.#{platform.name}.platform             = :#{platform.symbolic_name}, '#{platform.deployment_target}'
   s.#{platform.name}.vendored_framework   = '#{fwk_base}'
-SPEC
+RB
       else
        spec = <<SPEC
   s.#{platform.name}.platform             = :#{platform.symbolic_name}, '#{platform.deployment_target}'
@@ -40,7 +41,6 @@ SPEC
         value = "'#{value}'" if value.class == String
         spec += "  s.#{platform.name}.#{attribute} = #{value}\n"
       end
-
       spec
     end
 

--- a/lib/cocoapods-packager/symbols.rb
+++ b/lib/cocoapods-packager/symbols.rb
@@ -1,7 +1,6 @@
 module Symbols
   def symbols_from_library(library)
     syms = `nm -gU #{library}`.split("\n")
-    
     result = classes_from_symbols(syms)
     result = result + constants_from_symbols(syms)
 

--- a/lib/cocoapods-packager/symbols.rb
+++ b/lib/cocoapods-packager/symbols.rb
@@ -1,7 +1,7 @@
 module Symbols
   def symbols_from_library(library)
     syms = `nm -gU #{library}`.split("\n")
-
+    
     result = classes_from_symbols(syms)
     result = result + constants_from_symbols(syms)
 

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -1,5 +1,4 @@
 require 'tmpdir'
-require 'byebug'
 module Pod
   class Command
     class Package < Command

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 module Pod
 
-  CODESIGN_NOT_REQUIRED = true
+  DONT_CODESIGN = true
 
   describe Command::Spec::Package do
     describe 'CLAide' do

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -49,6 +49,19 @@ module Pod
         output[1].should.match /Mach-O dynamically linked shared library i386/
       end
 
+      it "should produce a dynamic library for OSX when dynamic is specified" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/KFData.podspec --dynamic })
+        command.run
+
+        lib = Dir.glob("KFData-*/osx/KFData.framework/KFData").first
+        file_command = "file #{lib}"
+        output = `#{file_command}`.lines.to_a
+
+        output[0].should.match /Mach-O 64-bit dynamically linked shared library x86_64/
+      end
+
       it "should produce a static library when dynamic is not specified" do
         SourcesManager.stubs(:search).returns(nil)
 

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -157,7 +157,7 @@ module Pod
         `rm armv7.a armv7s.a arm64.a`
       end
 
-      it "includes Bitcode for device arch slices when packaging an dynamic iOS  Pod" do
+      it "includes Bitcode for device arch slices when packaging an dynamic iOS Pod" do
         SourcesManager.stubs(:search).returns(nil)
 
         command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
@@ -210,17 +210,6 @@ module Pod
 
         #Check for ModuleCache references
         `strings #{lib}`.should.not.match /ModuleCache/
-      end
-
-      it "includes the correct architectures when packaging an iOS Pod as --dynamic" do
-        SourcesManager.stubs(:search).returns(nil)
-
-        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec })
-        command.run
-
-        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
-        `lipo #{lib} -verify_arch armv7 armv7s arm64`
-        $?.success?.should == true
       end
 
       it "does not fail when the pod name contains a dash" do

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -1,6 +1,9 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 module Pod
+
+  CODESIGN_NOT_REQUIRED = true
+
   describe Command::Spec::Package do
     describe 'CLAide' do
       after do

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -31,6 +31,35 @@ module Pod
         end.message.should.match /Unable to find/
       end
 
+
+      it "should produce a dynamic library when dynamic is specified" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        file_command = "file #{lib}"
+        output = `#{file_command}`.lines.to_a
+
+        output[0].should.match /Mach-O universal binary with 5 architectures/
+        output[1].should.match /Mach-O dynamically linked shared library i386/
+      end
+
+      it "should produce a static library when dynamic is not specified" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        file_command = "file #{lib}"
+        output = `#{file_command}`.lines.to_a
+
+        output[0].should.match /Mach-O universal binary with 5 architectures/
+        output[1].should.match /current ar archive random library/
+      end
+
       it "mangles symbols if the Pod has dependencies" do
         SourcesManager.stubs(:search).returns(nil)
 
@@ -39,8 +68,22 @@ module Pod
 
         lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
         symbols = Symbols.symbols_from_library(lib).uniq.sort.reject { |e| e =~ /PodNikeKit/ }
-        symbols.should == %w{ BBUNikePlusActivity BBUNikePlusSessionManager 
+
+        symbols.should == %w{ BBUNikePlusActivity BBUNikePlusSessionManager
                               BBUNikePlusTag }
+      end
+
+      it "mangles symbols if the Pod has dependencies and framework is dynamic" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        symbols = Symbols.symbols_from_library(lib).uniq.sort.reject { |e| e =~ /PodNikeKit/ }
+
+        symbols.should == %w{ BBUNikePlusActivity BBUNikePlusSessionManager
+                              BBUNikePlusTag NikeKitVersionNumber NikeKitVersionString }
       end
 
       it "mangles symbols if the Pod has dependencies regardless of name" do
@@ -51,7 +94,7 @@ module Pod
 
         lib = Dir.glob("a-*/ios/a.framework/a").first
         symbols = Symbols.symbols_from_library(lib).uniq.sort.reject { |e| e =~ /Poda/ }
-        symbols.should == %w{ BBUNikePlusActivity BBUNikePlusSessionManager 
+        symbols.should == %w{ BBUNikePlusActivity BBUNikePlusSessionManager
                                 BBUNikePlusTag }
       end
 
@@ -59,6 +102,17 @@ module Pod
         SourcesManager.stubs(:search).returns(nil)
 
         command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --no-mangle })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        symbols = Symbols.symbols_from_library(lib).uniq.sort.select { |e| e =~ /PodNikeKit/ }
+        symbols.should == []
+      end
+
+      it "does not mangle symbols if option --no-mangle and --dynamic are specified" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --no-mangle --dynamic })
         command.run
 
         lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
@@ -77,10 +131,36 @@ module Pod
         $?.success?.should == true
       end
 
+      it "includes the correct architectures when packaging an iOS Pod as --dynamic" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        `lipo #{lib} -verify_arch armv7 armv7s arm64`
+        $?.success?.should == true
+      end
+
       it "includes Bitcode for device arch slices when packaging an iOS Pod" do
         SourcesManager.stubs(:search).returns(nil)
 
         command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+
+        #Check for __LLVM segment in each device architecture
+        `lipo -extract armv7 #{lib} -o armv7.a && otool -l armv7.a`.should.match /__LLVM/
+        `lipo -extract armv7s #{lib} -o armv7s.a && otool -l armv7s.a`.should.match /__LLVM/
+        `lipo -extract arm64 #{lib} -o arm64.a && otool -l arm64.a`.should.match /__LLVM/
+        `rm armv7.a armv7s.a arm64.a`
+      end
+
+      it "includes Bitcode for device arch slices when packaging an dynamic iOS  Pod" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
         command.run
 
         lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
@@ -106,6 +186,20 @@ module Pod
         `rm i386.a x86_64.a`
       end
 
+      it "does not include Bitcode for simulator arch slices when packaging an dynamic iOS Pod" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+
+        #Check for __LLVM segment in each simulator architecture
+        `lipo -extract i386 #{lib} -o i386.a && otool -l i386.a`.should.not.match /__LLVM/
+        `lipo -extract x86_64 #{lib} -o x86_64.a && otool -l x86_64.a`.should.not.match /__LLVM/
+        `rm i386.a x86_64.a`
+      end
+
       it "does not include local ModuleCache references" do
         SourcesManager.stubs(:search).returns(nil)
 
@@ -116,6 +210,17 @@ module Pod
 
         #Check for ModuleCache references
         `strings #{lib}`.should.not.match /ModuleCache/
+      end
+
+      it "includes the correct architectures when packaging an iOS Pod as --dynamic" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        `lipo #{lib} -verify_arch armv7 armv7s arm64`
+        $?.success?.should == true
       end
 
       it "does not fail when the pod name contains a dash" do
@@ -154,12 +259,12 @@ MAP
         modulemap_contents.should == module_map
       end
 
-      #it "runs with a spec in the master repository" do
+      # it "runs with a spec in the master repository" do
       #  command = Command.parse(%w{ package KFData })
       #  command.run
-
+      #
       #  true.should == true  # To make the test pass without any shoulds
-      #end
+      # end
     end
   end
 end

--- a/spec/fixtures/KFData.podspec
+++ b/spec/fixtures/KFData.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.osx.deployment_target = '10.7'
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
 
   s.default_subspec = 'Essentials'
   s.header_dir = 'KFData'

--- a/spec/fixtures/LibraryDemo.podspec
+++ b/spec/fixtures/LibraryDemo.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.source              = { :git => 'https://github.com/olegam/LibraryDemo.git', :tag => s.version.to_s }
   s.source_files        = 'sources/**/*.{h,m}'
   s.requires_arc        = true
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.9'
 
 end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -27,6 +27,42 @@ module Pod
         $?.exitstatus.should == 0
   	 end
 
+     it 'Allow integration of dynamic framework into project alongside CocoaPods' do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --dynamic })
+        command.run
+        `cp -Rp NikeKit-*/ios/NikeKit.framework spec/fixtures/PackagerTest`
+
+        log = ''
+
+        Dir.chdir('spec/fixtures/PackagerTest') do
+          `pod install 2>&1`
+          log << `xcodebuild -workspace PackagerTest.xcworkspace -scheme PackagerTest -sdk iphonesimulator CODE_SIGN_IDENTITY=- 2>&1`
+        end
+
+        puts log if $?.exitstatus != 0
+        $?.exitstatus.should == 0
+  	 end
+
+     it 'allows integration of a dynamic library without dependencies' do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/LibraryDemo.podspec --dynamic})
+        command.run
+
+        log = ''
+
+        Dir.chdir('spec/fixtures/LibraryConsumerDemo') do
+          `pod install 2>&1`
+          log << `xcodebuild -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
+          log << `xcodebuild -sdk iphonesimulator -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
+        end
+
+        puts log if $?.exitstatus != 0
+        $?.exitstatus.should == 0
+     end
+
      it 'allows integration of a library without dependencies' do
         SourcesManager.stubs(:search).returns(nil)
 
@@ -43,7 +79,7 @@ module Pod
 
         puts log if $?.exitstatus != 0
         $?.exitstatus.should == 0
-     end 
+     end
     end
   end
 end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -45,24 +45,6 @@ module Pod
         $?.exitstatus.should == 0
   	 end
 
-     it 'allows integration of a dynamic library without dependencies' do
-        SourcesManager.stubs(:search).returns(nil)
-
-        command = Command.parse(%w{ package spec/fixtures/LibraryDemo.podspec --dynamic})
-        command.run
-
-        log = ''
-
-        Dir.chdir('spec/fixtures/LibraryConsumerDemo') do
-          `pod install 2>&1`
-          log << `xcodebuild -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
-          log << `xcodebuild -sdk iphonesimulator -workspace LibraryConsumer.xcworkspace -scheme LibraryConsumer 2>&1`
-        end
-
-        puts log if $?.exitstatus != 0
-        $?.exitstatus.should == 0
-     end
-
      it 'allows integration of a library without dependencies' do
         SourcesManager.stubs(:search).returns(nil)
 

--- a/spec/pod/utils_spec.rb
+++ b/spec/pod/utils_spec.rb
@@ -24,5 +24,28 @@ module Pod
       command = Command.parse(%w{ package spec/fixtures/KFData.podspec })
       command.send(:install_pod, :osx, nil)
     end
+
+    it "creates seperate static and dynamic target if dynamic is passed" do
+      SourcesManager.stubs(:search).returns(nil)
+
+      command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec -dynamic})
+      command. create_working_directory
+
+      command.config.sandbox_root       = 'Pods'
+      command.config.integrate_targets  = false
+      command.config.skip_repo_update   = true
+
+      static_sandbox = command.build_static_sandbox(true)
+      static_installer = command.install_pod(:ios, static_sandbox)
+
+      dynamic_sandbox = command.build_dynamic_sandbox(static_sandbox, static_installer)
+      command.install_dynamic_pod(dynamic_sandbox, static_sandbox, static_installer)
+
+      static_sandbox_dir = Dir.new(Dir.pwd << "/Pods/Static")
+      dynamic_sandbox_dir = Dir.new(Dir.pwd << "/Pods/Dynamic")
+
+      static_sandbox_dir.to_s.should.not.be.empty
+      dynamic_sandbox_dir.to_s.should.not.be.empty
+    end
   end
 end

--- a/spec/pod/utils_spec.rb
+++ b/spec/pod/utils_spec.rb
@@ -2,6 +2,10 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 module Pod
   describe Command::Package do
+    after do
+      Dir.glob("Pods").each { |dir| Pathname.new(dir).rmtree }
+    end
+
     it "uses additional spec repos passed on the command line" do
       SourcesManager.stubs(:search).returns(nil)
       nil::NilClass.any_instance.stubs(:install!)
@@ -26,6 +30,8 @@ module Pod
     end
 
     it "creates seperate static and dynamic target if dynamic is passed" do
+      source_dir = Dir.pwd
+
       SourcesManager.stubs(:search).returns(nil)
 
       command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec -dynamic})
@@ -46,6 +52,8 @@ module Pod
 
       static_sandbox_dir.to_s.should.not.be.empty
       dynamic_sandbox_dir.to_s.should.not.be.empty
+
+      Dir.chdir(source_dir)
     end
   end
 end

--- a/spec/pod/utils_spec.rb
+++ b/spec/pod/utils_spec.rb
@@ -5,23 +5,24 @@ module Pod
     it "uses additional spec repos passed on the command line" do
       SourcesManager.stubs(:search).returns(nil)
       nil::NilClass.any_instance.stubs(:install!)
-      Installer.expects(:new).with { 
-          |sandbox, podfile| podfile.sources == ['foo', 'bar'] 
-        }
+      Installer.expects(:new).with {
+        |sandbox, podfile| podfile.sources == ['foo', 'bar']
+      }
 
       command = Command.parse(%w{ package spec/fixtures/KFData.podspec --spec-sources=foo,bar})
-      command.send(:install_pod, :osx)
+      command.send(:install_pod, :osx, nil)
+
     end
 
     it "uses only the master repo if no spec repos were passed" do
       SourcesManager.stubs(:search).returns(nil)
       nil::NilClass.any_instance.stubs(:install!)
-      Installer.expects(:new).with { 
-          |sandbox, podfile| podfile.sources == ['https://github.com/CocoaPods/Specs.git'] 
+      Installer.expects(:new).with {
+          |sandbox, podfile| podfile.sources == ['https://github.com/CocoaPods/Specs.git']
         }
 
       command = Command.parse(%w{ package spec/fixtures/KFData.podspec })
-      command.send(:install_pod, :osx)
+      command.send(:install_pod, :osx, nil)
     end
   end
 end

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -6,16 +6,16 @@ module Pod
       describe 'compiler flags' do
         before do
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-          @builder = Builder.new(nil, nil, nil, @spec, nil, nil)
+          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil)
         end
-
+#ARCHS=\'x86_64 i386 arm64 armv7 armv7s\' OTHER_CFLAGS=\'-fembed-bitcode\'
         it "includes proper compiler flags for iOS" do
-          @builder.expects(:xcodebuild).with('GCC_PREPROCESSOR_DEFINITIONS=\'PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder\' -DBASE_FLAG -DIOS_FLAG', 'ARCHS="arm64 armv7 armv7s" OTHER_CFLAGS="-fembed-bitcode"').returns(nil)
+          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DIOS_FLAG", "ARCHS='x86_64 i386 arm64 armv7 armv7s' OTHER_CFLAGS='-fembed-bitcode'").returns(nil)
           @builder.compile(Platform.new(:ios))
         end
 
         it "includes proper compiler flags for OSX" do
-          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DOSX_FLAG", '').returns(nil)
+          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DOSX_FLAG", nil).returns(nil)
           @builder.compile(Platform.new(:osx))
         end
       end
@@ -23,7 +23,7 @@ module Pod
       describe 'on build failure' do
         before do
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-          @builder = Builder.new(nil, nil, nil, @spec, nil, nil)
+          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil)
         end
 
         it 'dumps report and terminates' do

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -8,7 +8,7 @@ module Pod
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
           @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil)
         end
-#ARCHS=\'x86_64 i386 arm64 armv7 armv7s\' OTHER_CFLAGS=\'-fembed-bitcode\'
+
         it "includes proper compiler flags for iOS" do
           @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DIOS_FLAG", "ARCHS='x86_64 i386 arm64 armv7 armv7s' OTHER_CFLAGS='-fembed-bitcode'").returns(nil)
           @builder.compile(Platform.new(:ios))

--- a/spec/specification/spec_builder_spec.rb
+++ b/spec/specification/spec_builder_spec.rb
@@ -24,7 +24,7 @@ module Pod
     describe 'Preserve attributes from source specification' do
       before do
         @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-        @builder = SpecBuilder.new(@spec, nil, false)
+        @builder = SpecBuilder.new(@spec, nil, false, nil)
       end
 
       it "preserves platform.frameworks" do


### PR DESCRIPTION
@neonichu This pull request adds support for building dynamic frameworks as discussed here https://github.com/CocoaPods/cocoapods-packager/issues/56. 

The methodology for building the dynamic framework is the following: 

1. Use existing packager code to build static frameworks for the target spec and all dependencies. 
2. Mangle the dependency symbols.
4. Create a second Pods project and install ONLY the target spec as a dynamic target (i.e. none of its dependencies). 
5. Build the dynamic target with mangled symbols and link against the dependency static frameworks. 
6. `Lipo` the device and simulator build artifacts to produce a single fat binary.

I spent a bunch of time in the `Xcodeproj` project trying to find a more elegant solution for producing the second pods project with the single dynamic target. I suspect there may be a better way than what I've come up with in `pod_utils.rb`...have a look and please let me know.

Thank you much!