### PR TITLE
Include Bitcode in iOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+osx_image: xcode7
 language: objective-c
 cache: bundler
 before_install:

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -75,17 +75,13 @@ module Pod
       `libtool -static -o #{output} #{static_libs.join(' ')}`
     end
 
-    def build_with_mangling(platform)
+    def build_with_mangling(platform, options)
       UI.puts 'Mangling symbols'
       defines = Symbols.mangle_for_pod_dependencies(@spec.name, @sandbox_root)
       defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
 
-      if platform.name == :ios
-        defines = "#{defines} ARCHS=\"x86_64 i386 arm64 armv7 armv7s\""
-      end
-
       UI.puts 'Building mangled framework'
-      xcodebuild(defines)
+      xcodebuild(defines, options)
       defines
     end
 
@@ -93,14 +89,15 @@ module Pod
       defines = "GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_#{@spec.name}=PodsDummy_PodPackage_#{@spec.name}'"
       defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
 
+      options = ""
       if platform.name == :ios
-        defines = "#{defines} ARCHS=\"x86_64 i386 arm64 armv7 armv7s\""
+        options = "ARCHS=\"arm64 armv7 armv7s\" OTHER_CFLAGS=\"-fembed-bitcode\"" 
       end
 
-      xcodebuild(defines)
+      xcodebuild(defines, options)
 
       if @mangle
-        return build_with_mangling(platform)
+        return build_with_mangling(platform, options)
       end
 
       defines

--- a/lib/cocoapods-packager/symbols.rb
+++ b/lib/cocoapods-packager/symbols.rb
@@ -3,7 +3,9 @@ module Symbols
     syms = `nm -gU #{library}`.split("\n")
 
     result = classes_from_symbols(syms)
-    result + constants_from_symbols(syms)
+    result = result + constants_from_symbols(syms)
+
+    result.reject { |e| e == "llvm.cmdline" || e == "llvm.embedded.module" }
   end
 
   module_function :symbols_from_library

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -10,12 +10,12 @@ module Pod
         end
 
         it "includes proper compiler flags for iOS" do
-          @builder.expects(:xcodebuild).with('GCC_PREPROCESSOR_DEFINITIONS=\'PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder\' -DBASE_FLAG -DIOS_FLAG ARCHS="x86_64 i386 arm64 armv7 armv7s"').returns(nil)
+          @builder.expects(:xcodebuild).with('GCC_PREPROCESSOR_DEFINITIONS=\'PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder\' -DBASE_FLAG -DIOS_FLAG', 'ARCHS="arm64 armv7 armv7s" OTHER_CFLAGS="-fembed-bitcode"').returns(nil)
           @builder.compile(Platform.new(:ios))
         end
 
         it "includes proper compiler flags for OSX" do
-          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DOSX_FLAG").returns(nil)
+          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DOSX_FLAG", '').returns(nil)
           @builder.compile(Platform.new(:osx))
         end
       end


### PR DESCRIPTION
This fixes #98.

Some useful reading: https://forums.developer.apple.com/thread/17529, http://www.openradar.me/21884601, https://forums.developer.apple.com/thread/3971

~~There is one very pesky known issue. Any framework built through this with mangling enabled gives tons of errors like this:~~

![screen_shot_2015-09-22_at_16 33 48](https://cloud.githubusercontent.com/assets/1773641/10023036/de5338e2-6147-11e5-9c08-5125a898c489.png)

~~This happens only if "Debug Information Format" is set to "DWARF with dSYM File". (We are seeing this issue in https://github.com/intercom/intercom-ios/issues/97).~~

~~If mangling is disabled the warnings go away (but of course we need mangling). Any ideas would be greatly appreciated.~~

(See comment below; this issue is unrelated).