### PR TITLE
Add option to exclude symbols in dependencies from static libraries/frameworks

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -1,6 +1,6 @@
 module Pod
   class Builder
-    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, dynamic)
+    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, dynamic, exclude_deps)
       @source_dir = source_dir
       @static_sandbox_root = static_sandbox_root
       @dynamic_sandbox_root = dynamic_sandbox_root
@@ -9,6 +9,7 @@ module Pod
       @embedded = embedded
       @mangle = mangle
       @dynamic = dynamic
+      @exclude_deps = exclude_deps
     end
 
     def build(platform, library)
@@ -245,7 +246,12 @@ MAP
     end
 
     def static_libs_in_sandbox(build_dir = 'build')
-      Dir.glob("#{@static_sandbox_root}/#{build_dir}/lib*.a")
+      if @exclude_deps
+        UI.puts 'Excluding dependencies'
+        Dir.glob("#{@static_sandbox_root}/#{build_dir}/lib#{@spec.name}.a")
+      else
+        Dir.glob("#{@static_sandbox_root}/#{build_dir}/lib*.a")
+      end
     end
 
     def static_linker_flags_in_sandbox

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -49,6 +49,7 @@ module Pod
         super
         help! 'A podspec name or path is required.' unless @spec
         help! 'podspec has binary-only depedencies, mangling not possible.' if @mangle and binary_only? @spec
+        help! '--exclude-deps option can only be used for static libraries' if @exclude_deps and @dynamic
       end
 
       def run

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -15,6 +15,7 @@ module Pod
           ['--embedded',  'Generate embedded frameworks.'],
           ['--library',   'Generate static libraries.'],
           ['--dynamic',   'Generate dynamic framework.'],
+          ['--exclude-deps', 'Exclude symbols from dependencies.'],
           ['--subspecs',  'Only include the given subspecs'],
           ['--spec-sources=private,https://github.com/CocoaPods/Specs.git', 'The sources to pull dependant ' \
             'pods from (defaults to https://github.com/CocoaPods/Specs.git)'],
@@ -27,6 +28,7 @@ module Pod
         @library = argv.flag?('library')
         @dynamic = argv.flag?('dynamic')
         @mangle = argv.flag?('mangle', true)
+        @exclude_deps = argv.flag?('exclude-deps', false)
         @name = argv.shift_argument
         @source = argv.shift_argument
         @spec_sources = argv.option('spec-sources', 'https://github.com/CocoaPods/Specs.git').split(',')
@@ -43,7 +45,7 @@ module Pod
       def validate!
         super
         help! 'A podspec name or path is required.' unless @spec
-        help! 'podspec has binary-only depedencies, mangling not possible.' if binary_only? @spec
+        help! 'podspec has binary-only depedencies, mangling not possible.' if @mangle and binary_only? @spec
       end
 
       def run
@@ -139,7 +141,8 @@ module Pod
           @spec,
           @embedded,
           @mangle,
-          @dynamic)
+          @dynamic,
+          @exclude_deps)
 
         builder.build(platform, @library)
 

--- a/spec/command/error_spec.rb
+++ b/spec/command/error_spec.rb
@@ -28,6 +28,13 @@ module Pod
       end.message.should.match /binary-only/
     end
 
+    it 'presents the help if both --exclude-deps and --dynamic are specified' do
+      command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --exclude-deps --dynamic })
+      should.raise CLAide::Help do
+        command.validate!
+      end.message.should.match /--exclude-deps option can only be used for static libraries/
+    end
+
     it 'can package a podspec with only resources' do
       command = Command.parse(%w{ package spec/fixtures/layer-client-messaging-schema.podspec --no-mangle })
       command.run

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -150,6 +150,17 @@ module Pod
         symbols.should == []
       end
 
+      it "does not include symbols from dependencies if option --exclude-deps is specified" do
+        SourcesManager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --exclude-deps })
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        symbols = Symbols.symbols_from_library(lib).uniq.sort.select { |e| e =~ /AFNetworking|ISO8601DateFormatter|KZPropertyMapper/ }
+        symbols.should == []
+      end
+
       it "includes the correct architectures when packaging an iOS Pod" do
         SourcesManager.stubs(:search).returns(nil)
 

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -6,7 +6,7 @@ module Pod
       describe 'compiler flags' do
         before do
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil)
+          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil, nil)
         end
 
         it "includes proper compiler flags for iOS" do

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -23,7 +23,7 @@ module Pod
       describe 'on build failure' do
         before do
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil)
+          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil, nil)
         end
 
         it 'dumps report and terminates' do


### PR DESCRIPTION
Added --exclude-deps option which excludes symbols from pod dependencies in the packaged static library or framework

This is an alternative to using symbol mangling which can lead to issues with code that relies on reflection, and also has the downside of bloating the app binary

Also fixed issue where the  "podspec has binary-only depedencies, mangling not possible" error is raised even when --no-mangle is specified.