### PR TITLE
Quiet warnings about unused build arguments

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -258,7 +258,7 @@ MAP
     end
 
     def ios_build_options
-      return "ARCHS=\'x86_64 i386 arm64 armv7 armv7s\' OTHER_CFLAGS=\'-fembed-bitcode\'"
+      return "ARCHS=\'x86_64 i386 arm64 armv7 armv7s\' OTHER_CFLAGS=\'-fembed-bitcode -Qunused-arguments\'"
     end
 
     def xcodebuild(defines = '', args = '', build_dir = 'build', target = 'Pods', project_root = @static_sandbox_root)

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -10,7 +10,7 @@ module Pod
         end
 
         it "includes proper compiler flags for iOS" do
-          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DIOS_FLAG", "ARCHS='x86_64 i386 arm64 armv7 armv7s' OTHER_CFLAGS='-fembed-bitcode'").returns(nil)
+          @builder.expects(:xcodebuild).with("GCC_PREPROCESSOR_DEFINITIONS='PodsDummy_Pods_Builder=PodsDummy_PodPackage_Builder' -DBASE_FLAG -DIOS_FLAG", "ARCHS='x86_64 i386 arm64 armv7 armv7s' OTHER_CFLAGS='-fembed-bitcode -Qunused-arguments'").returns(nil)
           @builder.compile(Platform.new(:ios))
         end
 


### PR DESCRIPTION
Build fails if warnings treats as errors.