### PR TITLE
add build options for tvos

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -161,6 +161,9 @@ module Pod
       if platform.name == :ios
         options = ios_build_options
       end
+      if platform.name ==:tvos
+        options = tvos_build_options
+      end
 
       xcodebuild(defines, options)
 
@@ -260,7 +263,11 @@ MAP
     def ios_build_options
       return "ARCHS=\'x86_64 i386 arm64 armv7 armv7s\' OTHER_CFLAGS=\'-fembed-bitcode -Qunused-arguments\'"
     end
-
+    
+    def tvos_build_options
+      return ios_build_options
+    end
+    
     def xcodebuild(defines = '', args = '', build_dir = 'build', target = 'Pods', project_root = @static_sandbox_root)
 
       if defined?(Pod::DONT_CODESIGN)


### PR DESCRIPTION
I am probably over simplifying the problem but frameworks built for tvos do not include symbols for simulator. So I was thinking including the archs for tvos builds would solve this issue. 