### PR TITLE
Avoid mangle for selected symbols

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -1,6 +1,6 @@
 module Pod
   class Builder
-    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, dynamic)
+    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, preserve_symbols, dynamic)
       @source_dir = source_dir
       @static_sandbox_root = static_sandbox_root
       @dynamic_sandbox_root = dynamic_sandbox_root
@@ -8,6 +8,7 @@ module Pod
       @spec = spec
       @embedded = embedded
       @mangle = mangle
+      @preserve_symbols = preserve_symbols
       @dynamic = dynamic
     end
 
@@ -137,7 +138,7 @@ module Pod
 
     def build_with_mangling(platform, options)
       UI.puts 'Mangling symbols'
-      defines = Symbols.mangle_for_pod_dependencies(@spec.name, @static_sandbox_root)
+      defines = Symbols.mangle_for_pod_dependencies(@spec.name, @static_sandbox_root, @preserve_symbols)
       defines << " " << @spec.consumer(platform).compiler_flags.join(' ')
 
       UI.puts 'Building mangled framework'

--- a/lib/cocoapods-packager/mangle.rb
+++ b/lib/cocoapods-packager/mangle.rb
@@ -5,19 +5,24 @@ module Symbols
   # for each dependency:
   # 	- determine symbols for classes and global constants
   # 	- alias each symbol to Pod#{pod_name}_#{symbol}
+  #   - avoid aliasing preserve symbol patterns
   # 	- put defines into `GCC_PREPROCESSOR_DEFINITIONS` for passing to Xcode
   #
-  def mangle_for_pod_dependencies(pod_name, sandbox_root)
+  def mangle_for_pod_dependencies(pod_name, sandbox_root, preserve_syms)
     pod_libs = Dir.glob("#{sandbox_root}/build/lib*.a").select do
       |file| file !~ /lib#{pod_name}.a$/
     end
 
     dummy_alias = alias_symbol "PodsDummy_#{pod_name}", pod_name
     all_syms = [dummy_alias]
+    
+    syms_patterns = preserve_syms.map { |s| Regexp.new(s) } unless preserve_syms.nil? 
+    syms_matcher = Regexp.union(syms_patterns) unless syms_patterns.nil?
 
     pod_libs.each do |pod_lib|
       syms = Symbols.symbols_from_library(pod_lib)
-      all_syms += syms.map! { |sym| alias_symbol sym, pod_name }
+      syms = syms.reject { |s| s.match(syms_matcher) } unless syms_matcher.nil?
+      all_syms += syms.map! { |sym| alias_symbol sym, pod_name  }
     end
 
     "GCC_PREPROCESSOR_DEFINITIONS='${inherited} #{all_syms.uniq.join(' ')}'"

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -10,12 +10,13 @@ module Pod
 
       def self.options
         [
-          ['--force',     'Overwrite existing files.'],
-          ['--no-mangle', 'Do not mangle symbols of depedendant Pods.'],
-          ['--embedded',  'Generate embedded frameworks.'],
-          ['--library',   'Generate static libraries.'],
-          ['--dynamic',   'Generate dynamic framework.'],
-          ['--subspecs',  'Only include the given subspecs'],
+          ['--force',            'Overwrite existing files.'],
+          ['--no-mangle',        'Do not mangle symbols of depedendant Pods.'],
+          ['--preserve-symbols', 'Do not mangle selected symbol patterns.'],
+          ['--embedded',         'Generate embedded frameworks.'],
+          ['--library',          'Generate static libraries.'],
+          ['--dynamic',          'Generate dynamic framework.'],
+          ['--subspecs',         'Only include the given subspecs'],
           ['--spec-sources=private,https://github.com/CocoaPods/Specs.git', 'The sources to pull dependant ' \
             'pods from (defaults to https://github.com/CocoaPods/Specs.git)'],
         ]
@@ -37,6 +38,9 @@ module Pod
         @source_dir = Dir.pwd
         @spec = spec_with_path(@name)
         @spec = spec_with_name(@name) unless @spec
+        
+        preserve_symbols = argv.option('preserve-symbols')
+        @preserve_symbols = preserve_symbols.split(',') unless preserve_symbols.nil?
         super
       end
 
@@ -138,6 +142,7 @@ module Pod
           @spec,
           @embedded,
           @mangle,
+          @preserve_symbols,
           @dynamic)
 
         builder.build(platform, @library)

--- a/spec/fixtures/cxa-symbols.podspec
+++ b/spec/fixtures/cxa-symbols.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = 'cxa-symbols'
+  s.version      = '0.0.1'
+  s.summary      = 'Objective-C implementation of the Nike+ API.'
+  s.homepage     = 'https://github.com/neonichu/NikeKit'
+  s.license      = {:type => 'MIT', :file => 'LICENSE'}
+  s.authors      = { 'Boris Bügling' => 'http://buegling.com' }
+  s.source       = { :git => 'https://github.com/neonichu/NikeKit.git', :tag => s.version.to_s }
+  s.platform     = :ios, '6.0'
+  
+  s.public_header_files = '*.h'
+  s.source_files = '*.{h,m}'
+  s.frameworks = 'Foundation'
+  s.requires_arc = true
+
+  s.dependency 'KSCrash', '0.0.5'
+  s.dependency 'AFNetworking'
+  s.dependency 'ISO8601DateFormatter'
+  s.dependency 'KZPropertyMapper'
+end


### PR DESCRIPTION
This changes are related to mangling functionality.
Some symbols should be presented without mangling in the end builds. Live example is `__cxa_throw` symbol which should be presented in static binary as-is in order to be callable by C++ exception machinery. 
As I say, example above affects only static libraries thanks to dynamic libraries' module maps. But until static libraries go away as a terrible dream an ability to excluding selected parts of package from mangling would be useful.