### PR TITLE
Add --bundle-identifier option for dynamic frameworks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ MethodLength:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -1,6 +1,6 @@
 module Pod
   class Builder
-    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, dynamic, config, exclude_deps)
+    def initialize(source_dir, static_sandbox_root, dynamic_sandbox_root, public_headers_root, spec, embedded, mangle, dynamic, config, bundle_identifier, exclude_deps)
       @source_dir = source_dir
       @static_sandbox_root = static_sandbox_root
       @dynamic_sandbox_root = dynamic_sandbox_root
@@ -10,6 +10,7 @@ module Pod
       @mangle = mangle
       @dynamic = dynamic
       @config = config
+      @bundle_identifier = bundle_identifier
       @exclude_deps = exclude_deps
     end
 
@@ -64,6 +65,10 @@ module Pod
 
     def build_dynamic_framework(platform, defines, output)
       UI.puts("Building dynamic Framework #{@spec} with configuration #{@config}")
+
+      if @bundle_identifier
+        defines = "#{defines} PRODUCT_BUNDLE_IDENTIFIER='#{@bundle_identifier}'"
+      end
 
       clean_directory_for_dynamic_build
       if platform.name == :ios

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -15,6 +15,7 @@ module Pod
           ['--embedded',  'Generate embedded frameworks.'],
           ['--library',   'Generate static libraries.'],
           ['--dynamic',   'Generate dynamic framework.'],
+          ['--bundle-identifier', 'Bundle identifier for dynamic framework'],
           ['--exclude-deps', 'Exclude symbols from dependencies.'],
           ['--configuration', 'Build the specified configuration (e.g. Debug). Defaults to Release'],
           ['--subspecs', 'Only include the given subspecs'],
@@ -29,6 +30,7 @@ module Pod
         @library = argv.flag?('library')
         @dynamic = argv.flag?('dynamic')
         @mangle = argv.flag?('mangle', true)
+        @bundle_identifier = argv.option('bundle-identifier', nil)
         @exclude_deps = argv.flag?('exclude-deps', false)
         @name = argv.shift_argument
         @source = argv.shift_argument
@@ -49,6 +51,7 @@ module Pod
         super
         help! 'A podspec name or path is required.' unless @spec
         help! 'podspec has binary-only depedencies, mangling not possible.' if @mangle && binary_only?(@spec)
+        help! '--bundle-identifier option can only be used for dynamic frameworks' if @bundle_identifier && !@dynamic
         help! '--exclude-deps option can only be used for static libraries' if @exclude_deps && @dynamic
       end
 
@@ -146,6 +149,7 @@ module Pod
           @mangle,
           @dynamic,
           @config,
+          @bundle_identifier,
           @exclude_deps
         )
 

--- a/spec/command/error_spec.rb
+++ b/spec/command/error_spec.rb
@@ -28,6 +28,13 @@ module Pod
       end.message.should.match /binary-only/
     end
 
+    it 'presents the help if only --bundle-identifier is specified' do
+      command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --bundle-identifier=com.example.NikeKit })
+      should.raise CLAide::Help do
+        command.validate!
+      end.message.should.match /--bundle-identifier option can only be used for dynamic frameworks/
+    end
+
     it 'presents the help if both --exclude-deps and --dynamic are specified' do
       command = Command.parse(%w{ package spec/fixtures/NikeKit.podspec --exclude-deps --dynamic })
       should.raise CLAide::Help do

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -103,6 +103,38 @@ module Pod
         output[0].should.match /Mach-O 64-bit dSYM companion file x86_64/
       end
 
+      it "should produce the default plist for iOS and OSX when --dynamic is specified but --bundle-identifier is not" do
+        Pod::Config.instance.sources_manager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/KFData.podspec --dynamic})
+        command.run
+
+        ios_plist = File.expand_path(Dir.glob("KFData-*/ios/KFData.framework/Info.plist").first)
+        osx_plist = File.expand_path(Dir.glob("KFData-*/osx/KFData.framework/Resources/Info.plist").first)
+
+        ios_bundle_id = `defaults read #{ios_plist} CFBundleIdentifier`
+        osx_bundle_id = `defaults read #{osx_plist} CFBundleIdentifier`
+
+        ios_bundle_id.should.match /org.cocoapods.KFData/
+        osx_bundle_id.should.match /org.cocoapods.KFData/
+      end
+
+      it "should produce the correct plist for iOS and OSX when --dynamic and --bundle-identifier are specified" do
+        Pod::Config.instance.sources_manager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/KFData.podspec --dynamic --bundle-identifier=com.example.KFData})
+        command.run
+
+        ios_plist = File.expand_path(Dir.glob("KFData-*/ios/KFData.framework/Info.plist").first)
+        osx_plist = File.expand_path(Dir.glob("KFData-*/osx/KFData.framework/Resources/Info.plist").first)
+
+        ios_bundle_id = `defaults read #{ios_plist} CFBundleIdentifier`
+        osx_bundle_id = `defaults read #{osx_plist} CFBundleIdentifier`
+
+        ios_bundle_id.should.match /com.example.KFData/
+        osx_bundle_id.should.match /com.example.KFData/
+      end
+
       it "should produce a static library when dynamic is not specified" do
         Pod::Config.instance.sources_manager.stubs(:search).returns(nil)
 

--- a/spec/specification/builder_spec.rb
+++ b/spec/specification/builder_spec.rb
@@ -6,7 +6,7 @@ module Pod
       describe 'compiler flags' do
         before do
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil, nil)
+          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil, nil, nil)
         end
 
         it "includes proper compiler flags for iOS" do
@@ -23,7 +23,7 @@ module Pod
       describe 'on build failure' do
         before do
           @spec = Specification.from_file('spec/fixtures/Builder.podspec')
-          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil, nil)
+          @builder = Builder.new(nil, nil, nil, nil, @spec, nil, nil, nil, nil, nil, nil)
         end
 
         it 'dumps report and terminates' do


### PR DESCRIPTION
This allows dynamic frameworks to have a custom bundle identifier (by default it is `org.cocoapods.PodName`).

Example usage is:
```
pod package NikeKit.podspec --dynamic --bundle-identifier=com.example.NikeKit
```

Discussed in #148.