### PR TITLE
Add --local option to use local sources while packaging

### DIFF
--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -64,7 +64,7 @@ module Pod
         help! 'podspec has binary-only depedencies, mangling not possible.' if @mangle && binary_only?(@spec)
         help! '--bundle-identifier option can only be used for dynamic frameworks' if @bundle_identifier && !@dynamic
         help! '--exclude-deps option can only be used for static libraries' if @exclude_deps && @dynamic
-        help! '--local option can only be used when a local `.podspec` path is given.' if @local && !@spec.local?
+        help! '--local option can only be used when a local `.podspec` path is given.' if @local && !@spec.defined_in_file
       end
 
       def run

--- a/lib/pod/command/package.rb
+++ b/lib/pod/command/package.rb
@@ -15,6 +15,7 @@ module Pod
           ['--embedded',  'Generate embedded frameworks.'],
           ['--library',   'Generate static libraries.'],
           ['--dynamic',   'Generate dynamic framework.'],
+          ['--local',     'Use local state rather than published versions.'],
           ['--bundle-identifier', 'Bundle identifier for dynamic framework'],
           ['--exclude-deps', 'Exclude symbols from dependencies.'],
           ['--configuration', 'Build the specified configuration (e.g. Debug). Defaults to Release'],
@@ -28,6 +29,7 @@ module Pod
         @embedded = argv.flag?('embedded')
         @library = argv.flag?('library')
         @dynamic = argv.flag?('dynamic')
+        @local = argv.flag?('local', false)
         @package_type = if @embedded
                           :static_framework
                         elsif @dynamic
@@ -62,6 +64,7 @@ module Pod
         help! 'podspec has binary-only depedencies, mangling not possible.' if @mangle && binary_only?(@spec)
         help! '--bundle-identifier option can only be used for dynamic frameworks' if @bundle_identifier && !@dynamic
         help! '--exclude-deps option can only be used for static libraries' if @exclude_deps && @dynamic
+        help! '--local option can only be used when a local `.podspec` path is given.' if @local && !@spec.local?
       end
 
       def run
@@ -133,7 +136,6 @@ module Pod
 
         work_dir = Dir.tmpdir + '/cocoapods-' + Array.new(8) { rand(36).to_s(36) }.join
         Pathname.new(work_dir).mkdir
-        `cp #{@path} #{work_dir}`
         Dir.chdir(work_dir)
 
         [target_dir, work_dir]

--- a/spec/command/error_spec.rb
+++ b/spec/command/error_spec.rb
@@ -42,6 +42,13 @@ module Pod
       end.message.should.match /--exclude-deps option can only be used for static libraries/
     end
 
+    it 'presents the help if --local is specified without .podspec path' do
+      command = Command.parse(%w{ package AFNetworking --local })
+      should.raise CLAide::Help do
+        command.validate!
+      end.message.should.match /--local option can only be used when a local `.podspec` path is given/
+    end
+
     it 'can package a podspec with only resources' do
       command = Command.parse(%w{ package spec/fixtures/layer-client-messaging-schema.podspec --no-mangle })
       command.run

--- a/spec/command/package_spec.rb
+++ b/spec/command/package_spec.rb
@@ -151,6 +151,17 @@ module Pod
         output[1].should.match /current ar archive/
       end
 
+      it "produces package using local sources when --local is specified" do
+        Pod::Config.instance.sources_manager.stubs(:search).returns(nil)
+
+        command = Command.parse(%w{ package spec/fixtures/LocalNikeKit.podspec --local})
+        command.run
+
+        lib = Dir.glob("NikeKit-*/ios/NikeKit.framework/NikeKit").first
+        symbols = Symbols.symbols_from_library(lib)
+        symbols.should.include('LocalNikeKit')
+        symbols.should.not.include('BBUNikePlusActivity')
+      end
 
       it "should include vendor symbols if the Pod has binary dependencies" do
         Pod::Config.instance.sources_manager.stubs(:search).returns(nil)

--- a/spec/fixtures/LocalSources/LocalNikeKit.h
+++ b/spec/fixtures/LocalSources/LocalNikeKit.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+@interface LocalNikeKit : NSObject
+@end

--- a/spec/fixtures/LocalSources/LocalNikeKit.m
+++ b/spec/fixtures/LocalSources/LocalNikeKit.m
@@ -1,0 +1,9 @@
+#import "LocalNikeKit.h"
+
+@implementation LocalNikeKit
+
+- (void)localMethod {
+
+}
+
+@end

--- a/spec/fixtures/LocalSources/LocalNikeKit.podspec
+++ b/spec/fixtures/LocalSources/LocalNikeKit.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = 'LocalNikeKit'
+  s.version      = '0.0.1'
+  s.summary      = 'Objective-C implementation of the Nike+ API.'
+  s.homepage     = 'https://github.com/neonichu/NikeKit'
+  s.license      = {:type => 'MIT', :file => 'LICENSE'}
+  s.authors      = { 'Boris Bügling' => 'http://buegling.com' }
+  s.source       = { :git => 'https://github.com/neonichu/NikeKit.git', :tag => s.version.to_s }
+  s.platform     = :ios, '8.0'
+  
+  s.public_header_files = '*.h'
+  s.source_files = '*.{h,m}'
+  s.frameworks = 'Foundation'
+  s.requires_arc = true
+
+  s.dependency 'AFNetworking'
+  s.dependency 'ISO8601DateFormatter'
+  s.dependency 'KZPropertyMapper'
+end


### PR DESCRIPTION
This adds support for packaging using local state of the source files, rather than using the latest version existing on given spec sources.

Proposed behavior is the following:

- `pod package AFNetworking` : Packages AFNetworking by downloading the source code from GitHub according to latest spec definitions existing in CocoaPods master source repo. This option will add the pod to generated Podfile as `pod AFNetworking`.
- `pod package /path/to/AFNetworking.podspec` : Packages AFNetworking by downloading the sources following the spec definitions inside `/path/to/AFNetworking.podspec` spec file. This option will add the pod to generated Podfile as `pod AFNetworking, :podspec => '/path/to/AFNetworking.podspec'`.
- `pod package --local /path/to/AFNetworking.podspec` : Packages AFNetworking using existing local sources, which will be found following the spec definitions inside `/path/to/AFNetworking.podspec` spec file. This option will add the pod to generated Podfile as `pod AFNetworking, :path => '/path/to/AFNetworking.podspec'`, meaning it will be regarded as a development pod.

I opened the PR based upon `manu-feature-vendored-libraries` branch because that branch contains general fixes to currently failing specs on master branch.