### PR TITLE
IOS-3409 - Adds Bitcode Support Back to XCode >=8.3

### DIFF
--- a/lib/cocoapods-packager/pod_utils.rb
+++ b/lib/cocoapods-packager/pod_utils.rb
@@ -135,6 +135,7 @@ module Pod
 
         # 9. Write the actual Xcodeproject to the dynamic sandbox.
         write_pod_project(project, dynamic_sandbox)
+        project
       end
 
       def build_dynamic_target(dynamic_sandbox, static_installer)
@@ -223,6 +224,7 @@ module Pod
             config.build_settings['HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
             config.build_settings['USER_HEADER_SEARCH_PATHS'] = "$(inherited) #{Dir.pwd}/Pods/Static/Headers/**"
             config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ObjC'
+            config.build_settings['BITCODE_GENERATION_MODE'] = "bitcode"
           end
           dynamic_project.save
         end


### PR DESCRIPTION
JIRA: https://layerhq.atlassian.net/browse/IOS-3409

XCode changed the default behavior when you build projects using `xcodebuild` which changes the linker arguments that get passed to the compiler and linker.

XCode v8.2 would implicitly compile and link with `-fembed-bitcode` releases, whereas XCode versions greater than v8.2 compile and link everything with `-fembed-bitcode-marker` (which zeroes all the bitcode symbol maps causing the binary to include an empty Bitcode section, probably because Bitcode is relevant only to the AppStore upload process), unless you manually run the **Build & Archive** from the IDE, then the code is compiled and linked with the `-fembed-bitcode` argument.