### PR TITLE
Fix LICENSE file not being copied

### DIFF
--- a/lib/cocoapods-packager/builder.rb
+++ b/lib/cocoapods-packager/builder.rb
@@ -223,6 +223,7 @@ MAP
 
     def copy_license
       license_file = @spec.license[:file] || 'LICENSE'
+      license_file = "#{@static_sandbox_root}/#{@spec.name}/#{license_file}"
       `cp "#{license_file}" .` if Pathname(license_file).exist?
     end
 


### PR DESCRIPTION
`LICENSE` is not being copied when packaging a pod due to the wrong source path of the LICENSE file.

Looks like the line of code that resolves LICENSE file path was deleted here where it should have been modified to `license_file = "#{@static_sandbox_root}/#{@spec.name}/#{license_file}"`.

https://github.com/CocoaPods/cocoapods-packager/commit/5fdbb7590a2cbc5866a726b4c7db1ec6ec3a3b06#diff-1df4a61f42e845f21c4bfb49e0675828L137