### PR TITLE
Skip exception mangle

### DIFF
--- a/lib/cocoapods-packager/symbols.rb
+++ b/lib/cocoapods-packager/symbols.rb
@@ -6,7 +6,7 @@ module Symbols
 
     result.select do |e|
       case e
-      when 'llvm.cmdline', 'llvm.embedded.module', '__clang_at_available_requires_core_foundation_framework'
+      when 'llvm.cmdline', 'llvm.embedded.module', '__clang_at_available_requires_core_foundation_framework', 'exception'
         false
       else
         true


### PR DESCRIPTION
Fix problem:

Undefined symbols for architecture arm64:
      "std::Pod_exception::what() const", referenced from:
          vtable for std::__1::bad_function_call in libDemo.a(Demo.o)
      "typeinfo for std::Pod_exception", referenced from:
          typeinfo for std::__1::bad_function_call in libDemo.a(Demo.o)
      "std::Pod_exception::~Pod_exception()", referenced from:
          std::__1::bad_function_call::~bad_function_call() in libDemo.a(Demo.o)
    ld: symbol(s) not found for architecture arm64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)